### PR TITLE
Update parser regex for splitting

### DIFF
--- a/lib/hon_graffiti_phoenix/parsers/markup_parser.ex
+++ b/lib/hon_graffiti_phoenix/parsers/markup_parser.ex
@@ -16,7 +16,7 @@ defmodule HonGraffitiPhoenix.Parsers.MarkupParser do
   # This captures(named style) on a caret followed by EITHER
   # one of the characters, or 3 digits
   @capture_style_separately ~r/\^(?<color>\d{3}|[wrbymnpkotvg*])(?<body>.*)/i
-  @caret_regex ~r/\^.*?(?=\^)/
+  @caret_regex ~r/\^[^\^]*/
 
 #  Public functions
   @spec parse :: []

--- a/test/lib/markdown_parser_test.exs
+++ b/test/lib/markdown_parser_test.exs
@@ -7,7 +7,14 @@ defmodule HonGraffitiPhoenix.MarkupParserTest do
   @no_markdown "thisIsSoFakn' BORING"
   @broken_markdown "this^Qmakes no ^09s sense!!"
   @invalid_markup_code "^j doesn't coorespond to a code"
+  @caret_not_first "this is a ^rrandom string"
 
+
+  test "it returns the original string if there is no style" do
+    parsed = MarkupParser.parse(@no_markdown)
+    assert length(parsed) == 1
+    assert hd(parsed).body == @no_markdown
+  end
 
   test "it returns the caret if the style code is invalid" do
     parsed = MarkupParser.parse(@invalid_markup_code)
@@ -15,10 +22,10 @@ defmodule HonGraffitiPhoenix.MarkupParserTest do
     assert hd(parsed).body == @invalid_markup_code
   end
 
-  test "it returns the original string if there is no style" do
-    parsed = MarkupParser.parse(@no_markdown)
-    assert length(parsed) == 1
-    assert hd(parsed).body == @no_markdown
+  test "it parses strings that don't start with carets" do
+    parsed = MarkupParser.parse(@caret_not_first)
+    assert length(parsed) == 2
+    assert hd(parsed).body == "this is a "
   end
 
   test "parsing an empty quote returns an empty list" do
@@ -29,7 +36,7 @@ defmodule HonGraffitiPhoenix.MarkupParserTest do
     assert length(MarkupParser.parse(@quote)) == 3
   end
 
-  test "invalid markup won't be parsed into a color, default is white" do
+  test "it will default to white if there is no valid markup" do
     markdown_data = MarkupParser.parse(@broken_markdown)
     color_array = Enum.reduce(markdown_data, [], fn(color_struct, acc) -> [Map.fetch!(color_struct, :color) | acc] end)
     assert Enum.all?(color_array, fn(x) -> x == "white" end)

--- a/test/lib/markdown_parser_test.exs
+++ b/test/lib/markdown_parser_test.exs
@@ -6,7 +6,7 @@ defmodule HonGraffitiPhoenix.MarkupParserTest do
   @quote "^rBold ^gWow ^*Nein"
   @no_markdown "thisIsSoFakn' BORING"
   @broken_markdown "this^Qmakes no ^09s sense!!"
-  @invalid_markup_code "^j doesn't coorespond to a code"
+  @invalid_markup_code "^j doesn't correspond to a code"
   @caret_not_first "this is a ^rrandom string"
 
 


### PR DESCRIPTION
Added a test to catch strings that don't start with
carets to ensure we still add them